### PR TITLE
[FIX] multiple instances of @codemirror/state are loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@codemirror/matchbrackets": "^0.19.0",
     "@codemirror/rectangular-selection": "^0.19.0",
     "@codemirror/search": "^0.19.0",
-    "@codemirror/state": "^0.19.0",
+    "@codemirror/state": "^0.19.2",
     "@codemirror/view": "^0.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I couldn't load Codemirror 6 through skypack CDN. It's reported [here](https://github.com/lezer-parser/javascript/issues/6#issuecomment-943228164). 

When importing through jsDelivr CDN. it throws error
```js
Uncaught Error: Unrecognized extension value in extension set ([object Object]). This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.
```

So I'm updating `@codemirror/state` version.

Note: Please enable Github dependabot alerts to avoid these errors in future.