### PR TITLE
fix: module @codemirror/state does not provide an export named Extension

### DIFF
--- a/src/codemirror.ts
+++ b/src/codemirror.ts
@@ -1,7 +1,8 @@
 import {keymap, highlightSpecialChars, drawSelection, highlightActiveLine, dropCursor,
         rectangularSelection, crosshairCursor,
         lineNumbers, highlightActiveLineGutter} from "@codemirror/view"
-import {Extension, EditorState} from "@codemirror/state"
+import {EditorState} from "@codemirror/state"
+import type {Extension} from "@codemirror/state"
 import {defaultHighlightStyle, syntaxHighlighting, indentOnInput, bracketMatching,
         foldGutter, foldKeymap} from "@codemirror/language"
 import {defaultKeymap, history, historyKeymap} from "@codemirror/commands"


### PR DESCRIPTION
found this error when copy-pasting from https://github.com/codemirror/basic-setup

```js
import {Extension, EditorState} from "@codemirror/state"
```

```
Uncaught SyntaxError: The requested module @codemirror/state does not provide an export named 'Extension' (at App.jsx:48:9)
```

fixed by removing the `Extension` import in my code

relevant code

https://github.com/codemirror/state/blob/8725a90b185bdfac81e3d2c1fef1a8fd9435e774/src/index.ts#L3

```ts
export {Facet, StateField, Extension, Prec, Compartment} from "./facet"
```

https://github.com/codemirror/state/blob/8725a90b185bdfac81e3d2c1fef1a8fd9435e774/src/facet.ts#L343

```ts
export type Extension = {extension: Extension} | readonly Extension[]
```

as far as i can tell, `Extension` is only a type
